### PR TITLE
Add Hacker News best stories ASP.NET Core API

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -48,3 +48,34 @@ To deploy the Mini-Billing-Solution, follow these steps:
         Receipt: https://mini-billing-receiptapi.rj.r.appspot.com/
         
         CustomersWeb: https://mini-billing-solution.uc.r.appspot.com/
+
+## Hacker News Best Stories API
+
+This repository also includes a small ASP.NET Core API that returns the top `n` best stories from the Hacker News API.
+
+### Running the API
+
+1. Ensure you have the .NET 8 SDK installed.
+2. From the repository root, run:
+
+    ```bash
+    cd src/HackerNewsApi
+    dotnet run
+    ```
+
+3. Query the API:
+
+    ```bash
+    curl "http://localhost:5000/api/beststories?n=10"
+    ```
+
+### Assumptions
+
+- The caller supplies the `n` query parameter, and it must be greater than zero.
+- Only items of type `story` are returned, mirroring the Hacker News item API contract.
+
+### Potential Enhancements
+
+- Add distributed caching (e.g., Redis) for multi-instance deployments.
+- Add resiliency policies (retry/backoff) for transient Hacker News API failures.
+- Add pagination/validation limits and OpenAPI/Swagger documentation.

--- a/src/HackerNewsApi/HackerNewsApi.csproj
+++ b/src/HackerNewsApi/HackerNewsApi.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+</Project>

--- a/src/HackerNewsApi/Models/BestStoryDto.cs
+++ b/src/HackerNewsApi/Models/BestStoryDto.cs
@@ -1,0 +1,11 @@
+namespace HackerNewsApi.Models;
+
+public sealed class BestStoryDto
+{
+    public string? Title { get; set; }
+    public string? Uri { get; set; }
+    public string? PostedBy { get; set; }
+    public string? Time { get; set; }
+    public int Score { get; set; }
+    public int CommentCount { get; set; }
+}

--- a/src/HackerNewsApi/Models/HackerNewsItem.cs
+++ b/src/HackerNewsApi/Models/HackerNewsItem.cs
@@ -1,0 +1,13 @@
+namespace HackerNewsApi.Models;
+
+public sealed class HackerNewsItem
+{
+    public string? By { get; set; }
+    public int Descendants { get; set; }
+    public int Id { get; set; }
+    public int Score { get; set; }
+    public long Time { get; set; }
+    public string? Title { get; set; }
+    public string? Type { get; set; }
+    public string? Url { get; set; }
+}

--- a/src/HackerNewsApi/Options/HackerNewsOptions.cs
+++ b/src/HackerNewsApi/Options/HackerNewsOptions.cs
@@ -1,0 +1,8 @@
+namespace HackerNewsApi.Options;
+
+public sealed class HackerNewsOptions
+{
+    public TimeSpan BestStoriesCacheDuration { get; set; } = TimeSpan.FromMinutes(2);
+    public TimeSpan StoryCacheDuration { get; set; } = TimeSpan.FromMinutes(5);
+    public int MaxConcurrentRequests { get; set; } = 10;
+}

--- a/src/HackerNewsApi/Program.cs
+++ b/src/HackerNewsApi/Program.cs
@@ -1,0 +1,39 @@
+using HackerNewsApi.Options;
+using HackerNewsApi.Services;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddMemoryCache();
+
+builder.Services.Configure<HackerNewsOptions>(options =>
+{
+    options.BestStoriesCacheDuration = TimeSpan.FromMinutes(2);
+    options.StoryCacheDuration = TimeSpan.FromMinutes(5);
+    options.MaxConcurrentRequests = 10;
+});
+
+builder.Services.AddHttpClient<IHackerNewsClient, HackerNewsClient>(client =>
+{
+    client.BaseAddress = new Uri("https://hacker-news.firebaseio.com/v0/");
+    client.DefaultRequestHeaders.UserAgent.ParseAdd("mini-billing-solution/1.0");
+});
+
+var app = builder.Build();
+
+app.MapGet("/api/beststories", async (int? n, IHackerNewsClient client, CancellationToken cancellationToken) =>
+{
+    if (n is null)
+    {
+        return Results.BadRequest(new { error = "Query parameter 'n' is required." });
+    }
+
+    if (n <= 0)
+    {
+        return Results.BadRequest(new { error = "Query parameter 'n' must be greater than zero." });
+    }
+
+    var stories = await client.GetBestStoriesAsync(n.Value, cancellationToken);
+    return Results.Ok(stories);
+});
+
+app.Run();

--- a/src/HackerNewsApi/Services/HackerNewsClient.cs
+++ b/src/HackerNewsApi/Services/HackerNewsClient.cs
@@ -1,0 +1,94 @@
+using System.Net.Http.Json;
+using HackerNewsApi.Models;
+using HackerNewsApi.Options;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Options;
+
+namespace HackerNewsApi.Services;
+
+public sealed class HackerNewsClient : IHackerNewsClient
+{
+    private const string BestStoriesCacheKey = "hackernews.beststories";
+    private readonly HttpClient _httpClient;
+    private readonly IMemoryCache _memoryCache;
+    private readonly HackerNewsOptions _options;
+
+    public HackerNewsClient(HttpClient httpClient, IMemoryCache memoryCache, IOptions<HackerNewsOptions> options)
+    {
+        _httpClient = httpClient;
+        _memoryCache = memoryCache;
+        _options = options.Value;
+    }
+
+    public async Task<IReadOnlyList<BestStoryDto>> GetBestStoriesAsync(int count, CancellationToken cancellationToken)
+    {
+        var ids = await GetBestStoryIdsAsync(cancellationToken);
+        var selectedIds = ids.Take(count).ToArray();
+
+        var throttler = new SemaphoreSlim(_options.MaxConcurrentRequests);
+        var tasks = selectedIds.Select(async id =>
+        {
+            await throttler.WaitAsync(cancellationToken);
+            try
+            {
+                return await GetStoryAsync(id, cancellationToken);
+            }
+            finally
+            {
+                throttler.Release();
+            }
+        });
+
+        var stories = await Task.WhenAll(tasks);
+
+        return stories
+            .Where(story => story is not null)
+            .Select(story => story!)
+            .OrderByDescending(story => story.Score)
+            .ToList();
+    }
+
+    private async Task<IReadOnlyList<int>> GetBestStoryIdsAsync(CancellationToken cancellationToken)
+    {
+        if (_memoryCache.TryGetValue(BestStoriesCacheKey, out IReadOnlyList<int>? cachedIds))
+        {
+            return cachedIds;
+        }
+
+        var ids = await _httpClient.GetFromJsonAsync<List<int>>("beststories.json", cancellationToken)
+            ?? new List<int>();
+
+        _memoryCache.Set(BestStoriesCacheKey, ids, _options.BestStoriesCacheDuration);
+
+        return ids;
+    }
+
+    private async Task<BestStoryDto?> GetStoryAsync(int id, CancellationToken cancellationToken)
+    {
+        var cacheKey = $"hackernews.item.{id}";
+        if (_memoryCache.TryGetValue(cacheKey, out BestStoryDto? cachedStory))
+        {
+            return cachedStory;
+        }
+
+        var item = await _httpClient.GetFromJsonAsync<HackerNewsItem>($"item/{id}.json", cancellationToken);
+        if (item is null || !string.Equals(item.Type, "story", StringComparison.OrdinalIgnoreCase))
+        {
+            return null;
+        }
+
+        var story = new BestStoryDto
+        {
+            Title = item.Title,
+            Uri = item.Url,
+            PostedBy = item.By,
+            Time = DateTimeOffset.FromUnixTimeSeconds(item.Time).ToString("O"),
+            Score = item.Score,
+            CommentCount = item.Descendants
+        };
+
+        _memoryCache.Set(cacheKey, story, _options.StoryCacheDuration);
+
+        return story;
+    }
+}

--- a/src/HackerNewsApi/Services/IHackerNewsClient.cs
+++ b/src/HackerNewsApi/Services/IHackerNewsClient.cs
@@ -1,0 +1,8 @@
+using HackerNewsApi.Models;
+
+namespace HackerNewsApi.Services;
+
+public interface IHackerNewsClient
+{
+    Task<IReadOnlyList<BestStoryDto>> GetBestStoriesAsync(int count, CancellationToken cancellationToken);
+}


### PR DESCRIPTION
### Motivation

- Provide a lightweight REST API to return the first `n` Hacker News "best stories" sorted by score as required by the spec.
- Avoid overloading the Hacker News API by adding caching and controlled concurrency for item fetches.
- Ship a minimal, runnable example that can be started from the repository and documented in the `readme.md`.

### Description

- Added a new ASP.NET Core minimal API project at `src/HackerNewsApi` with `HackerNewsApi.csproj` and `Program.cs` exposing `GET /api/beststories?n=<int>`.
- Implemented `HackerNewsOptions` to configure cache durations and `MaxConcurrentRequests` and wired `IMemoryCache` and `HttpClient` in DI.
- Added models `HackerNewsItem` and `BestStoryDto` and the `IHackerNewsClient` interface with `HackerNewsClient` implementation that caches the best-stories list and individual items, fetches story details in parallel with a `SemaphoreSlim` throttle, maps items to the DTO, and returns results ordered by `Score` descending.
- Updated `readme.md` to document how to run the new API, assumptions, and suggested enhancements (e.g., Redis, resiliency policies, Swagger).

### Testing

- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697d09d04684832f84f4da7e32130a33)